### PR TITLE
[feat] add aizynthfinder dependency to the main agent

### DIFF
--- a/src/reagentai/agents/main/main_agent.py
+++ b/src/reagentai/agents/main/main_agent.py
@@ -1,11 +1,28 @@
+from dataclasses import dataclass
+
+from aizynthfinder.aizynthfinder import AiZynthFinder
 from pydantic_ai import Tool
 
 from src.reagentai.common.client import LLMClient
-from src.reagentai.tools.retrosynthesis import perform_retrosynthesis
+from src.reagentai.constants import AIZYNTHFINDER_CONFIG_PATH
+from src.reagentai.tools.retrosynthesis import (
+    initialize_aizynthfinder,
+    perform_retrosynthesis,
+)
 from src.reagentai.tools.smiles import is_valid_smiles
 
 MAIN_AGENT_INSTRUCTIONS_PATH: str = "src/reagentai/agents/main/instructions.txt"
 MAIN_AGENT_MODEL: str = "google-gla:gemini-2.0-flash"
+
+
+@dataclass
+class MainAgentDependencyTypes:
+    """
+    Defines the dependencies required by the main agent.
+    This includes the AiZynthFinder instance for retrosynthesis tasks.
+    """
+
+    aizynth_finder: AiZynthFinder
 
 
 def create_main_agent() -> LLMClient:
@@ -16,11 +33,27 @@ def create_main_agent() -> LLMClient:
         LLMClient: An instance of LLMClient configured with the main agent's model and instructions.
     """
 
+    # Load instructions
     with open(MAIN_AGENT_INSTRUCTIONS_PATH) as instructions_file:
         instructions = instructions_file.read()
 
+    # Define tools for the main agent
     tools = [Tool(perform_retrosynthesis), Tool(is_valid_smiles)]
 
-    llm_client = LLMClient(model_name=MAIN_AGENT_MODEL, tools=tools, instructions=instructions)
+    aizynth_finder = initialize_aizynthfinder(
+        config_path=AIZYNTHFINDER_CONFIG_PATH,
+        stock="zinc",
+        expansion_policy="uspto",
+        filter_policy="uspto",
+    )
+
+    # Initialize the LLM client
+    llm_client = LLMClient(
+        model_name=MAIN_AGENT_MODEL,
+        tools=tools,
+        instructions=instructions,
+        dependency_types=MainAgentDependencyTypes,
+        dependencies=MainAgentDependencyTypes(aizynth_finder=aizynth_finder),
+    )
 
     return llm_client

--- a/src/reagentai/main.py
+++ b/src/reagentai/main.py
@@ -3,9 +3,7 @@ import logging
 from dotenv import load_dotenv
 
 from src.reagentai.agents.main.main_agent import create_main_agent
-from src.reagentai.constants import AIZYNTHFINDER_CONFIG_PATH
 from src.reagentai.logging import setup_logging
-from src.reagentai.tools.retrosynthesis import initialize_aizynthfinder_globally
 from src.reagentai.ui.app import create_gradio_app
 
 logger = logging.getLogger(__name__)
@@ -14,12 +12,6 @@ logger = logging.getLogger(__name__)
 def start_agent():
     setup_logging()
     load_dotenv()
-    initialize_aizynthfinder_globally(
-        config_path=AIZYNTHFINDER_CONFIG_PATH,
-        stock="zinc",
-        expansion_policy="uspto",
-        filter_policy="uspto",
-    )
 
     main_agent = create_main_agent()
     app = create_gradio_app(main_agent)


### PR DESCRIPTION
# Summary

Add pydatnic-ai dependencies to the main agent so an instance of the AiZynthFinder is passed in the context instead of a global finder being created at the start of the application.

## Changes
- Remove global aizynthfinder instance and the related code.
- Add expected dependency types dataclass for the main agent.
- Create dependencies for the main agent and the aizynthfinder instance creation function.
- Change the LLMClient class to hold both dependencies and expected dependency types for the agent.