### PR TITLE
[feat] example prompts

### DIFF
--- a/src/reagentai/agents/main/main_agent.py
+++ b/src/reagentai/agents/main/main_agent.py
@@ -9,7 +9,7 @@ from src.reagentai.tools.retrosynthesis import (
     initialize_aizynthfinder,
     perform_retrosynthesis,
 )
-from src.reagentai.tools.smiles import image_from_smiles, is_valid_smiles
+from src.reagentai.tools.smiles import is_valid_smiles, smiles_to_image
 
 MAIN_AGENT_INSTRUCTIONS_PATH: str = "src/reagentai/agents/main/instructions.txt"
 MAIN_AGENT_MODEL: str = "google-gla:gemini-2.0-flash"
@@ -37,7 +37,7 @@ def create_main_agent() -> LLMClient:
     with open(MAIN_AGENT_INSTRUCTIONS_PATH) as instructions_file:
         instructions = instructions_file.read()
 
-    tools = [Tool(perform_retrosynthesis), Tool(is_valid_smiles), Tool(image_from_smiles)]
+    tools = [Tool(perform_retrosynthesis), Tool(is_valid_smiles), Tool(smiles_to_image)]
 
     aizynth_finder = initialize_aizynthfinder(
         config_path=AIZYNTHFINDER_CONFIG_PATH,

--- a/src/reagentai/constants.py
+++ b/src/reagentai/constants.py
@@ -6,6 +6,12 @@ AVAILABLE_LLM_MODELS = [
     "gemini-2.5-flash-preview-04-17",
 ]
 AIZYNTHFINDER_CONFIG_PATH: str = "data/config.yml"
+EXAMPLE_PROMPTS = [
+    "Show the SMILES and structure of Caffeine.",
+    "Suggest a retrosynthesis for Aspirin. Show the top 3 routes.",
+    "Suggest a retrosynthesis for Ibuprofen. Show molecule images from the first route.",
+]
+
 DEFAULT_LOG_LEVEL: int = INFO
 LOG_DIR: Path = Path("logs")
 LOG_TO_FILE: bool = True

--- a/src/reagentai/constants.py
+++ b/src/reagentai/constants.py
@@ -9,7 +9,7 @@ AIZYNTHFINDER_CONFIG_PATH: str = "data/config.yml"
 EXAMPLE_PROMPTS = [
     "Show the SMILES and structure of Caffeine.",
     "Suggest a retrosynthesis for Aspirin. Show the top 3 routes.",
-    "Suggest a retrosynthesis for Ibuprofen. Show molecule images from the first route.",
+    "Suggest a retrosynthesis for Ibuprofen. Show all molecule images from the first route.",
 ]
 
 DEFAULT_LOG_LEVEL: int = INFO

--- a/src/reagentai/tools/smiles.py
+++ b/src/reagentai/tools/smiles.py
@@ -29,13 +29,13 @@ def is_valid_smiles(smiles: str, sanitize: bool = True) -> bool:
     return mol is not None
 
 
-def image_from_smiles(smiles: str, size: tuple[int, int] = (300, 300)) -> str:
+def image_from_smiles(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
     """
     Generate an image from a SMILES string.
 
     Args:
         smiles (str): The SMILES string to convert to an image.
-        size (tuple[int, int]): The size of the image in pixels. Default is (300, 300).
+        size (tuple[int, int]): The size of the image in pixels. Default is (600, 300).
 
     Returns:
         str: The file path to the generated image.

--- a/src/reagentai/tools/smiles.py
+++ b/src/reagentai/tools/smiles.py
@@ -29,7 +29,7 @@ def is_valid_smiles(smiles: str, sanitize: bool = True) -> bool:
     return mol is not None
 
 
-def image_from_smiles(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
+def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
     """
     Generate an image from a SMILES string.
 

--- a/src/reagentai/ui/app.py
+++ b/src/reagentai/ui/app.py
@@ -3,12 +3,12 @@ import functools
 import gradio as gr
 
 from src.reagentai.common.client import LLMClient
-from src.reagentai.constants import AVAILABLE_LLM_MODELS
+from src.reagentai.constants import AVAILABLE_LLM_MODELS, EXAMPLE_PROMPTS
 
 
 # UI Creation Helper Functions
-def create_settings_panel():
-    with gr.Column(scale=1, min_width=250):
+def create_settings_panel(chat_input_component: gr.MultimodalTextbox):
+    with gr.Column(scale=1, min_width=200):
         gr.Markdown("### Model Settings")
         llm_model_dropdown = gr.Dropdown(
             label="Select LLM Model",
@@ -22,6 +22,14 @@ def create_settings_panel():
             interactive=False,
             visible=True,
         )
+
+        gr.Markdown("### Examples")
+        gr.Examples(
+            examples=EXAMPLE_PROMPTS,
+            inputs=chat_input_component,
+            show_label=False,
+        )
+
     return llm_model_dropdown, token_usage_display
 
 
@@ -102,8 +110,8 @@ def create_gradio_app(llm_client: LLMClient):
         )
 
         with gr.Row():
-            llm_model_dropdown, token_usage_display = create_settings_panel()
             chatbot_display, chat_input = create_chat_interface()
+            llm_model_dropdown, token_usage_display = create_settings_panel(chat_input)
 
         # Event handling
         chat_input.submit(

--- a/src/reagentai/ui/app.py
+++ b/src/reagentai/ui/app.py
@@ -27,7 +27,6 @@ def create_settings_panel(chat_input_component: gr.MultimodalTextbox):
         gr.Examples(
             examples=EXAMPLE_PROMPTS,
             inputs=chat_input_component,
-            show_label=False,
         )
 
     return llm_model_dropdown, token_usage_display


### PR DESCRIPTION
This pull request introduces new functionality and UI improvements to the `reagentai` application, along with a minor adjustment to an existing utility function. The most notable changes include adding example prompts for the user interface, modifying the image generation function to use a wider aspect ratio, and updating the settings panel to integrate the new examples feature.

### New functionality and UI improvements:

* **Added example prompts for the UI**: Introduced a new constant, `EXAMPLE_PROMPTS`, in `src/reagentai/constants.py` to provide predefined examples for users. These prompts are integrated into the settings panel via a new `gr.Examples` component, which populates the chat input field when selected. [[1]](diffhunk://#diff-912741cf295ee99e7e5d4bca8dd64fe9c50144e1d6dd5143656874dfa660db8cR9-R14) [[2]](diffhunk://#diff-7e7877cc50a61b0dcfd5967029196c6422aa795d6767d11a3ff5812b1d972dc7R25-R32)
* **Updated `create_settings_panel` function**: Modified the function to accept a `chat_input_component` parameter and adjusted the layout to include the example prompts section. [[1]](diffhunk://#diff-7e7877cc50a61b0dcfd5967029196c6422aa795d6767d11a3ff5812b1d972dc7L6-R11) [[2]](diffhunk://#diff-7e7877cc50a61b0dcfd5967029196c6422aa795d6767d11a3ff5812b1d972dc7R25-R32)
* **Updated `create_gradio_app` function**: Passed the `chat_input` component to `create_settings_panel` to enable the new examples feature.

### Utility function adjustment:

* **Changed default image size in `image_from_smiles`**: Updated the default size of generated images from `(300, 300)` to `(600, 300)` to provide a wider aspect ratio, improving visualization for certain molecular structures.