### PR TITLE
[feat] add new tool – route to image

### DIFF
--- a/src/reagentai/agents/main/main_agent.py
+++ b/src/reagentai/agents/main/main_agent.py
@@ -5,11 +5,12 @@ from pydantic_ai import Tool
 
 from src.reagentai.common.client import LLMClient
 from src.reagentai.constants import AIZYNTHFINDER_CONFIG_PATH
+from src.reagentai.tools.drawing import route_to_image, smiles_to_image
 from src.reagentai.tools.retrosynthesis import (
     initialize_aizynthfinder,
     perform_retrosynthesis,
 )
-from src.reagentai.tools.smiles import is_valid_smiles, smiles_to_image
+from src.reagentai.tools.smiles import is_valid_smiles
 
 MAIN_AGENT_INSTRUCTIONS_PATH: str = "src/reagentai/agents/main/instructions.txt"
 MAIN_AGENT_MODEL: str = "google-gla:gemini-2.0-flash"
@@ -37,7 +38,12 @@ def create_main_agent() -> LLMClient:
     with open(MAIN_AGENT_INSTRUCTIONS_PATH) as instructions_file:
         instructions = instructions_file.read()
 
-    tools = [Tool(perform_retrosynthesis), Tool(is_valid_smiles), Tool(smiles_to_image)]
+    tools = [
+        Tool(perform_retrosynthesis),
+        Tool(is_valid_smiles),
+        Tool(smiles_to_image),
+        Tool(route_to_image),
+    ]
 
     aizynth_finder = initialize_aizynthfinder(
         config_path=AIZYNTHFINDER_CONFIG_PATH,

--- a/src/reagentai/models/retrosynthesis.py
+++ b/src/reagentai/models/retrosynthesis.py
@@ -48,7 +48,7 @@ class NodeBase(BaseModel):
         children (list[str]): List of IDs of child nodes (default is an empty list).
     """
 
-    id: str
+    node_id: str
     smiles: str
     children: list[str] = Field(default_factory=list)
 
@@ -81,13 +81,15 @@ class Route(BaseModel):
     Represents a retrosynthetic route consisting of molecular and reaction nodes.
 
     Attributes:
-        score_data (ScoreData): The scoring information associated with the route.
+        route_id (int): Unique identifier for the route.
         root_node_id (str): The identifier of the root node in the route.
+        score_data (ScoreData): The scoring information associated with the route.
         mols_nodes (list[MolNode]): List of molecular nodes in the route.
         reactions_nodes (list[ReactionNode]): List of reaction nodes in the route.
     """
-    score_data: ScoreData
+    route_id: int
     root_node_id: str
+    score_data: ScoreData
     mol_nodes: list[MolNode] = Field(default_factory=list)
     reaction_nodes: list[ReactionNode] = Field(default_factory=list)
 

--- a/src/reagentai/models/retrosynthesis.py
+++ b/src/reagentai/models/retrosynthesis.py
@@ -2,7 +2,8 @@ from typing import Union
 
 from pydantic import BaseModel, Field
 
-Node = Union["MolNode", "ReactionNode"]
+
+Node = Union['MolNode', 'ReactionNode']
 
 
 class ReactionMetadata(BaseModel):
@@ -18,9 +19,9 @@ class ReactionMetadata(BaseModel):
     policy_probability: float
 
 
-class Score(BaseModel):
+class ScoreData(BaseModel):
     """
-    Score for a retrosynthesis route.
+    Represents the scoring data for a retrosynthesis route.
 
     Attributes:
         state_score (float): Overall score for the retrosynthesis state.
@@ -37,55 +38,58 @@ class Score(BaseModel):
     avg_template_occurence: float
 
 
-class MolNode(BaseModel):
+class NodeBase(BaseModel):
     """
-    Represents a molecular node in the retrosynthesis route.
+    Represents a base node in a retrosynthesis tree.
 
     Attributes:
-        type (str): Type of the node, should be "mol".
-        in_stock (bool): Indicates if the molecule is in stock.
-        is_chemical (bool): Indicates if the node represents a chemical.
-        smiles (str): SMILES representation of the molecule.
-        children (List[Node]): List of child nodes, which can be either molecular or reaction nodes.
+        id (str): Unique identifier for the node.
+        smiles (str): SMILES string representing the chemical structure.
+        children (list[str]): List of IDs of child nodes (default is an empty list).
     """
 
-    type: str
+    id: str
+    smiles: str
+    children: list[str] = Field(default_factory=list)
+
+
+class MolNode(NodeBase):
+    """
+    Represents a molecular node in a retrosynthesis graph.
+
+    Attributes:
+        in_stock (bool): Indicates whether the molecule is available in stock.
+        is_chemical (bool): Specifies if the node represents a chemical entity.
+    """
+
     in_stock: bool
     is_chemical: bool
-    smiles: str
-    children: list[Node] = Field(default=list)
 
 
-class ReactionNode(BaseModel):
+class ReactionNode(NodeBase):
     """
-    Represents a reaction node in the retrosynthesis route.
+    Represents a node in a retrosynthesis reaction tree.
 
     Attributes:
-        type (str): Type of the node, should be "reaction".
-        smiles (str): SMILES representation of the reaction.
         metadata (ReactionMetadata): Metadata associated with the reaction.
-        children (List[Node]): List of child nodes, which can be either molecular or reaction nodes.
     """
 
-    type: str
-    smiles: str
     metadata: ReactionMetadata
-    children: list[Node] = Field(default=list)
-
 
 class Route(BaseModel):
     """
-    Represents a retrosynthesis route.
+    Represents a retrosynthetic route consisting of molecular and reaction nodes.
 
     Attributes:
-        id (str): Unique identifier for the route.
-        target_smiles (str): SMILES representation of the target molecule.
-        scores (Score): Score associated with the route.
-        root_node (Node): The root node of the retrosynthesis route, which can be a molecular or reaction node.
+        score_data (ScoreData): The scoring information associated with the route.
+        root_node_id (str): The identifier of the root node in the route.
+        mols_nodes (list[MolNode]): List of molecular nodes in the route.
+        reactions_nodes (list[ReactionNode]): List of reaction nodes in the route.
     """
-
-    score: Score
-    root_node: Node
+    score_data: ScoreData
+    root_node_id: str
+    mol_nodes: list[MolNode] = Field(default_factory=list)
+    reaction_nodes: list[ReactionNode] = Field(default_factory=list)
 
 
 class RouteCollection(BaseModel):

--- a/src/reagentai/models/retrosynthesis.py
+++ b/src/reagentai/models/retrosynthesis.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from pydantic import BaseModel, Field
 
-Node = Union['MolNode', 'ReactionNode']
+Node = Union["MolNode", "ReactionNode"]
 
 
 class ReactionMetadata(BaseModel):
@@ -75,6 +75,7 @@ class ReactionNode(NodeBase):
 
     metadata: ReactionMetadata
 
+
 class Route(BaseModel):
     """
     Represents a retrosynthetic route consisting of molecular and reaction nodes.
@@ -86,6 +87,7 @@ class Route(BaseModel):
         mol_nodes (list[MolNode]): List of molecular nodes in the route.
         reaction_nodes (list[ReactionNode]): List of reaction nodes in the route.
     """
+
     route_id: int
     root_node_id: str
     score_data: ScoreData

--- a/src/reagentai/models/retrosynthesis.py
+++ b/src/reagentai/models/retrosynthesis.py
@@ -2,7 +2,6 @@ from typing import Union
 
 from pydantic import BaseModel, Field
 
-
 Node = Union['MolNode', 'ReactionNode']
 
 

--- a/src/reagentai/models/retrosynthesis.py
+++ b/src/reagentai/models/retrosynthesis.py
@@ -28,14 +28,14 @@ class ScoreData(BaseModel):
         n_reactions (int): Number of reactions in the route.
         n_precursors (int): Number of precursors in the route.
         n_precursors_in_stock (int): Number of precursors that are in stock.
-        avg_template_occurence (float): Average occurrence of templates in the route.
+        avg_template_occurrence (float): Average occurrence of templates in the route.
     """
 
     state_score: float
     n_reactions: int
     n_precursors: int
     n_precursors_in_stock: int
-    avg_template_occurence: float
+    avg_template_occurrence: float
 
 
 class NodeBase(BaseModel):
@@ -84,8 +84,8 @@ class Route(BaseModel):
         route_id (int): Unique identifier for the route.
         root_node_id (str): The identifier of the root node in the route.
         score_data (ScoreData): The scoring information associated with the route.
-        mols_nodes (list[MolNode]): List of molecular nodes in the route.
-        reactions_nodes (list[ReactionNode]): List of reaction nodes in the route.
+        mol_nodes (list[MolNode]): List of molecular nodes in the route.
+        reaction_nodes (list[ReactionNode]): List of reaction nodes in the route.
     """
     route_id: int
     root_node_id: str

--- a/src/reagentai/tools/drawing.py
+++ b/src/reagentai/tools/drawing.py
@@ -1,0 +1,58 @@
+import logging
+import tempfile
+
+from PIL import Image
+from rdkit import Chem
+from rdkit.Chem import Draw
+
+from src.reagentai.models.retrosynthesis import Route
+
+from .helpers import RouteImageFactory
+
+logger = logging.getLogger(__name__)
+
+
+def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
+    """
+    Generate an image from a SMILES string.
+
+    Args:
+        smiles (str): The SMILES string to convert to an image.
+        size (tuple[int, int]): The size of the image in pixels. Default is (600, 300).
+
+    Returns:
+        str: The file path to the generated image.
+    """
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES string: {smiles}")
+
+    PIL_img: Image.Image = Draw.MolToImage(mol, size=size, kekulize=True)
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+        PIL_img.save(tmp_file, format="PNG")
+        temp_file_path = tmp_file.name
+
+    logger.info(f"Generated image for SMILES: {smiles}, saved to {temp_file_path}")
+    return temp_file_path
+
+
+def route_to_image(routes: Route) -> str:
+    """
+    Generate an image from a SMILES route.
+
+    Args:
+        routes (RouteCollection): The collection of retrosynthesis routes.
+        idx (int): The index of the route to generate an image for. Default is 0.
+
+    Returns:
+        str: The file path to the generated image.
+    """
+    image = RouteImageFactory(routes).image
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+        image.save(tmp_file, format="PNG")
+        temp_file_path = tmp_file.name
+
+    logger.info(f"Generated image for route, saved to {temp_file_path}")
+    return temp_file_path

--- a/src/reagentai/tools/drawing.py
+++ b/src/reagentai/tools/drawing.py
@@ -37,17 +37,17 @@ def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
     return temp_file_path
 
 
-def route_to_image(routes: Route) -> str:
+def route_to_image(route: Route) -> str:
     """
     Generate an image from a retrosynthesis route.
 
     Args:
-        routes (Route): The retrosynthesis route to convert to an image.
+        route (Route): The retrosynthesis route to convert to an image.
 
     Returns:
         str: The file path to the generated image.
     """
-    image = RouteImageFactory(routes).image
+    image = RouteImageFactory(route).image
 
     with tempfile.NamedTemporaryFile(prefix="reagentai_route_", suffix=".png", delete=False) as tmp_file:
         image.save(tmp_file, format="PNG")

--- a/src/reagentai/tools/drawing.py
+++ b/src/reagentai/tools/drawing.py
@@ -29,7 +29,9 @@ def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
 
     PIL_img: Image.Image = Draw.MolToImage(mol, size=size, kekulize=True)
 
-    with tempfile.NamedTemporaryFile(prefix="reagentai_smiles_", suffix=".png", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(
+        prefix="reagentai_smiles_", suffix=".png", delete=False
+    ) as tmp_file:
         PIL_img.save(tmp_file, format="PNG")
         temp_file_path = tmp_file.name
 
@@ -49,7 +51,9 @@ def route_to_image(route: Route) -> str:
     """
     image = RouteImageFactory(route).image
 
-    with tempfile.NamedTemporaryFile(prefix="reagentai_route_", suffix=".png", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(
+        prefix="reagentai_route_", suffix=".png", delete=False
+    ) as tmp_file:
         image.save(tmp_file, format="PNG")
         temp_file_path = tmp_file.name
 

--- a/src/reagentai/tools/drawing.py
+++ b/src/reagentai/tools/drawing.py
@@ -29,7 +29,7 @@ def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
 
     PIL_img: Image.Image = Draw.MolToImage(mol, size=size, kekulize=True)
 
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(prefix="reagentai_smiles_", suffix=".png", delete=False) as tmp_file:
         PIL_img.save(tmp_file, format="PNG")
         temp_file_path = tmp_file.name
 
@@ -50,7 +50,7 @@ def route_to_image(routes: Route) -> str:
     """
     image = RouteImageFactory(routes).image
 
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+    with tempfile.NamedTemporaryFile(prefix="reagentai_route_", suffix=".png", delete=False) as tmp_file:
         image.save(tmp_file, format="PNG")
         temp_file_path = tmp_file.name
 

--- a/src/reagentai/tools/drawing.py
+++ b/src/reagentai/tools/drawing.py
@@ -42,8 +42,7 @@ def route_to_image(routes: Route) -> str:
     Generate an image from a SMILES route.
 
     Args:
-        routes (RouteCollection): The collection of retrosynthesis routes.
-        idx (int): The index of the route to generate an image for. Default is 0.
+        routes (Route): The retrosynthesis route to convert to an image.
 
     Returns:
         str: The file path to the generated image.

--- a/src/reagentai/tools/drawing.py
+++ b/src/reagentai/tools/drawing.py
@@ -39,7 +39,7 @@ def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
 
 def route_to_image(routes: Route) -> str:
     """
-    Generate an image from a SMILES route.
+    Generate an image from a retrosynthesis route.
 
     Args:
         routes (Route): The retrosynthesis route to convert to an image.

--- a/src/reagentai/tools/helpers.py
+++ b/src/reagentai/tools/helpers.py
@@ -327,11 +327,11 @@ class RouteImageFactory:
         children_height = sum(c["eff_height"] for c in children) + self.margin * (
             len(children) - 1
         )
-        childen_leftmost = pos[0] - self.margin - max(c["image"].width for c in children)
+        children_leftmost = pos[0] - self.margin - max(c["image"].width for c in children)
         child_y = mid_y - int(children_height * 0.5)
         for child in children:
             y_adjust = int((child["eff_height"] - child["image"].height) * 0.5)
-            self._add_pos(child, (childen_leftmost, child_y + y_adjust))
+            self._add_pos(child, (children_leftmost, child_y + y_adjust))
             child_y += self.margin + child["eff_height"]
 
     def _make_image(self, tree_dict: dict):

--- a/src/reagentai/tools/helpers.py
+++ b/src/reagentai/tools/helpers.py
@@ -82,7 +82,7 @@ def parse_node(node_dict: dict, state: NodeProcessingState) -> str:
     """
 
     node_type = node_dict["type"]
-    children_data = node_dict["children"]
+    children_data = node_dict.get("children", [])
 
     current_node_id = state.get_next_id(node_type)
 

--- a/src/reagentai/tools/helpers.py
+++ b/src/reagentai/tools/helpers.py
@@ -7,7 +7,6 @@ from rdkit.Chem import Draw
 
 from src.reagentai.models.retrosynthesis import (
     MolNode,
-    Node,
     ReactionMetadata,
     ReactionNode,
     Route,
@@ -15,6 +14,7 @@ from src.reagentai.models.retrosynthesis import (
 )
 
 
+### Helper classes and functions for processing retrosynthesis routes
 class NodeProcessingState:
     """Helper class to keep track of ID counters and collected nodes."""
 
@@ -25,6 +25,14 @@ class NodeProcessingState:
         self.processed_reaction_nodes: list[ReactionNode] = []
 
     def get_next_id(self, node_type: Literal["mol", "reaction"]) -> str:
+        """
+        Generates the next unique ID for a node based on its type.
+        Args:
+            node_type (Literal["mol", "reaction"]): The type of the node for which to generate an ID.
+        Returns:
+            str: A unique identifier for the node, formatted as "mol-{counter}" or "react-{counter}".
+        """
+
         if node_type == "mol":
             self.mol_counter += 1
             return f"mol-{self.mol_counter}"
@@ -36,6 +44,15 @@ class NodeProcessingState:
 
 
 def parse_route_score(score_dict: dict) -> ScoreData:
+    """
+    Parses a score dictionary from the LLM response into a ScoreData object.
+
+    Args:
+        score_dict (dict): The dictionary containing score data from the LLM response.
+    Returns:
+        ScoreData: An instance of ScoreData populated with the parsed values.
+    """
+
     key_map = {
         "state score": "state_score",
         "number of reactions": "n_reactions",
@@ -53,6 +70,17 @@ def parse_route_score(score_dict: dict) -> ScoreData:
 
 
 def parse_node(node_dict: dict, state: NodeProcessingState) -> str:
+    """
+    Recursively parses a node dictionary into a MolNode or ReactionNode object,
+    updating the processing state with the parsed nodes.
+
+    Args:
+        node_dict (dict): The dictionary representation of the node.
+        state (NodeProcessingState): The state object to keep track of IDs and processed nodes.
+    Returns:
+        str: The unique identifier for the parsed node.
+    """
+
     node_type = node_dict.get("type")
     children_data = node_dict.get("children", [])
 
@@ -70,14 +98,14 @@ def parse_node(node_dict: dict, state: NodeProcessingState) -> str:
     }
 
     if node_type == "mol":
-        node_data["in_stock"] = node_dict.get("in stock", False)
-        node_data["is_chemical"] = node_dict.get("is chemical", True)
+        node_data["in_stock"] = node_dict.get("in_stock", False)
+        node_data["is_chemical"] = node_dict.get("is_chemical", True)
         parsed_node = MolNode(**node_data)
         state.processed_mol_nodes.append(parsed_node)
     elif node_type == "reaction":
         metadata = ReactionMetadata(
             classification=node_dict.get("classification", ""),
-            policy_probability=node_dict.get("policy probability", 0.0),
+            policy_probability=node_dict.get("policy_probability", 0.0),
         )
         node_data["metadata"] = metadata
         parsed_node = ReactionNode(**node_data)
@@ -87,6 +115,16 @@ def parse_node(node_dict: dict, state: NodeProcessingState) -> str:
 
 
 def parse_route_dict(route_dict: dict, route_id: int) -> Route:
+    """
+    Parses a route dictionary into a Route object.
+
+    Args:
+        route_dict (dict): The dictionary representation of the route.
+        route_id (int): The unique identifier for the route.
+    Returns:
+        Route: An instance of Route populated with the parsed data.
+    """
+
     score_data = parse_route_score(route_dict["scores"])
     processing_state = NodeProcessingState()
 
@@ -101,7 +139,18 @@ def parse_route_dict(route_dict: dict, route_id: int) -> Route:
     )
 
 
+### Image processing functions for retrosynthesis routes
+### Copied and refined from the AiZynthFinder project
 def crop_image(img: PilImage, margin: int = 20) -> PilImage:
+    """
+    Crops the image to remove white borders and adds a margin around the cropped area.
+
+    Args:
+        img: The PIL Image to crop.
+        margin: The margin to add around the cropped area.
+    Returns:
+        A new PIL Image with the cropped content and added margin.
+    """
     non_white_pixels = PilImage.eval(img, lambda x: 255 - x).getbbox()
     if not non_white_pixels:
         return img
@@ -111,25 +160,60 @@ def crop_image(img: PilImage, margin: int = 20) -> PilImage:
     return out
 
 
-def draw_rounded_rectangle(img: PilImage.Image, color: str, arc_size: int = 20) -> PilImage:
+def draw_rounded_rectangle(
+    img: PilImage.Image,
+    color: str,
+    arc_size: int = 20,
+    width: int = 2,
+) -> PilImage.Image:
+    """
+    Draws a rounded rectangle border on a copy of the given image.
+
+    Args:
+        img: The PIL Image to draw on.
+        color: Color of the rectangle border.
+        arc_size: Diameter of the corner arcs.
+        border_width: Width of the border line.
+
+    Returns:
+        A new PIL Image with the rounded rectangle border.
+    """
+
     copy = img.copy()
     draw = ImageDraw.Draw(copy)
     x0, y0, x1, y1 = 0, 0, copy.width - 1, copy.height - 1
     arc_size_half = arc_size // 2
-    draw.arc((x0, y0, x0 + arc_size, y0 + arc_size), 180, 270, color, width=2)
-    draw.arc((x1 - arc_size, y0, x1, y0 + arc_size), 270, 360, color, width=2)
-    draw.arc((x1 - arc_size, y1 - arc_size, x1, y1), 0, 90, color, width=2)
-    draw.arc((x0, y1 - arc_size, x0 + arc_size, y1), 90, 180, color, width=2)
-    draw.line((x0 + arc_size_half, y0, x1 - arc_size_half, y0), fill=color, width=2)
-    draw.line((x1, y0 + arc_size_half, x1, y1 - arc_size_half), fill=color, width=2)
-    draw.line((x0 + arc_size_half, y1, x1 - arc_size_half, y1), fill=color, width=2)
-    draw.line((x0, y0 + arc_size_half, x0, y1 - arc_size_half), fill=color, width=2)
+
+    # Arcs for corners
+    draw.arc((x0, y0, x0 + arc_size, y0 + arc_size), 180, 270, color, width=width)
+    draw.arc((x1 - arc_size, y0, x1, y0 + arc_size), 270, 360, color, width=width)
+    draw.arc((x1 - arc_size, y1 - arc_size, x1, y1), 0, 90, color, width=width)
+    draw.arc((x0, y1 - arc_size, x0 + arc_size, y1), 90, 180, color, width=width)
+
+    # Lines connecting arcs
+    draw.line((x0 + arc_size_half, y0, x1 - arc_size_half, y0), fill=color, width=width)  # Top
+    draw.line((x1, y0 + arc_size_half, x1, y1 - arc_size_half), fill=color, width=width)  # Right
+    draw.line((x0 + arc_size_half, y1, x1 - arc_size_half, y1), fill=color, width=width)  # Bottom
+    draw.line((x0, y0 + arc_size_half, x0, y1 - arc_size_half), fill=color, width=width)  # Left
     return copy
 
 
 def molecules_to_images(
-    mols: list[MolNode], in_stock_colors: dict[bool, str], size: int = 400
+    mols: list[MolNode],
+    in_stock_colors: dict[bool, str],
+    size: int = 400,
 ) -> list[PilImage.Image]:
+    """
+    Converts a list of MolNode objects to a list of PIL images with rounded rectangles.
+
+    Args:
+        mols (list[MolNode]): List of MolNode objects to convert.
+        in_stock_colors (dict[bool, str]): Dictionary mapping in-stock status to colors.
+        size (int): Size of the images to generate.
+    Returns:
+        list[PilImage.Image]: List of PIL images with rounded rectangles.
+    """
+
     rd_mols = [Chem.MolFromSmiles(mol.smiles) for mol in mols]
     grid_img = Draw.MolsToGridImage(rd_mols, molsPerRow=len(mols), subImgSize=(size, size))
 
@@ -147,11 +231,16 @@ def molecules_to_images(
 
 
 class RouteImageFactory:
+    """
+    Factory class to create an image representation of a retrosynthetic route.
+    This class builds a tree structure from the route's molecular and reaction nodes,
+    calculates their effective sizes, positions them, and draws the final image.
+    """
+
     def __init__(self, route: Route, margin: int = 100, mol_size: int = 400):
         in_stock_colors = {True: "green", False: "orange"}
         self.margin = margin
         self.mol_size = mol_size
-        font_size = max(16, self.mol_size // 15)
         self.font = ImageFont.load_default()
 
         images = molecules_to_images(
@@ -183,13 +272,11 @@ class RouteImageFactory:
         )
         self._draw = ImageDraw.Draw(self.image)
         self._make_image(self._mol_tree)
-        # self.image = crop_image(self.image, margin=0)
+        self.image = crop_image(self.image, margin=40)
 
     def _build_plot_tree(self, current_mol_node: MolNode) -> dict | None:
-        """
-        Recursively builds a tree structure for plotting, starting from a MolNode object.
-        It uses the node lists within self.route to resolve children by their IDs.
-        """
+        """Recursively builds a tree structure for plotting, starting from a MolNode object."""
+
         tree_dict = {
             "smiles": current_mol_node.smiles,
             "image": self._image_lookup[current_mol_node.smiles],
@@ -211,9 +298,12 @@ class RouteImageFactory:
         return tree_dict
 
     def _add_effective_size(self, tree_dict: dict):
+        """Recursively calculates the effective size of the tree dictionary."""
+
         children = tree_dict.get("children", [])
         for child in children:
             self._add_effective_size(child)
+
         if children:
             tree_dict["eff_height"] = sum(c["eff_height"] for c in children) + self.margin * (
                 len(children) - 1
@@ -226,6 +316,8 @@ class RouteImageFactory:
             tree_dict["eff_width"] = tree_dict["image"].width + self.margin
 
     def _add_pos(self, tree_dict: dict, pos: tuple[int, int]):
+        """Recursively adds position information to the tree dictionary."""
+
         tree_dict["left"] = pos[0]
         tree_dict["top"] = pos[1]
         children = tree_dict.get("children")
@@ -243,6 +335,8 @@ class RouteImageFactory:
             child_y += self.margin + child["eff_height"]
 
     def _make_image(self, tree_dict: dict):
+        """Draws the molecule image and its connections on the canvas."""
+
         self.image.paste(tree_dict["image"], (tree_dict["left"], tree_dict["top"]))
         self._draw_number_on_frame(tree_dict)
         children = tree_dict.get("children")
@@ -271,8 +365,9 @@ class RouteImageFactory:
             (mid_x - 8, mid_y - 8, mid_x + 8, mid_y + 8), fill="black", outline="black"
         )
 
-    def _draw_number_on_frame(self, tree_dict: dict):  # REVISED METHOD
+    def _draw_number_on_frame(self, tree_dict: dict):
         """Draws the molecule ID as black text on the top-left corner of its frame."""
+
         image_x, image_y = tree_dict["left"], tree_dict["top"]
         mol_id = tree_dict["id"]
         text = str(mol_id)
@@ -286,5 +381,5 @@ class RouteImageFactory:
             text_pos,
             text,
             font=self.font,
-            fill="black",  # Changed from "white"
+            fill="black",
         )

--- a/src/reagentai/tools/helpers.py
+++ b/src/reagentai/tools/helpers.py
@@ -1,7 +1,15 @@
-from typing import Literal
+import io
+import shutil
+import tempfile
+from typing import Generator, Literal
+
+from PIL import Image as PilImage, ImageColor as PilColor, ImageDraw, ImageFont
+from rdkit import Chem
+from rdkit.Chem import Draw
 
 from src.reagentai.models.retrosynthesis import (
     MolNode,
+    Node,
     ReactionMetadata,
     ReactionNode,
     Route,
@@ -92,3 +100,191 @@ def parse_route_dict(route_dict: dict) -> Route:
         mol_nodes=processing_state.processed_mol_nodes,
         reaction_nodes=processing_state.processed_reaction_nodes,
     )
+
+
+def crop_image(img: PilImage, margin: int = 20) -> PilImage:
+    non_white_pixels = PilImage.eval(img, lambda x: 255 - x).getbbox()
+    if not non_white_pixels:
+        return img
+    cropped = img.crop(non_white_pixels)
+    out = PilImage.new("RGB", (cropped.width + 2 * margin, cropped.height + 2 * margin), "white")
+    out.paste(cropped, (margin, margin))
+    return out
+
+
+def draw_rounded_rectangle(img: PilImage.Image, color: str, arc_size: int = 20) -> PilImage:
+    copy = img.copy()
+    draw = ImageDraw.Draw(copy)
+    x0, y0, x1, y1 = 0, 0, copy.width - 1, copy.height - 1
+    arc_size_half = arc_size // 2
+    draw.arc((x0, y0, x0 + arc_size, y0 + arc_size), 180, 270, color, width=2)
+    draw.arc((x1 - arc_size, y0, x1, y0 + arc_size), 270, 360, color, width=2)
+    draw.arc((x1 - arc_size, y1 - arc_size, x1, y1), 0, 90, color, width=2)
+    draw.arc((x0, y1 - arc_size, x0 + arc_size, y1), 90, 180, color, width=2)
+    draw.line((x0 + arc_size_half, y0, x1 - arc_size_half, y0), fill=color, width=2)
+    draw.line((x1, y0 + arc_size_half, x1, y1 - arc_size_half), fill=color, width=2)
+    draw.line((x0 + arc_size_half, y1, x1 - arc_size_half, y1), fill=color, width=2)
+    draw.line((x0, y0 + arc_size_half, x0, y1 - arc_size_half), fill=color, width=2)
+    return copy
+
+
+def molecules_to_images(
+    mols: dict[int, str], frame_colors: list[str], size: int = 400
+) -> list[PilImage.Image]:
+    rd_mols = [Chem.MolFromSmiles(smiles) for smiles in mols.values()]
+    grid_img = Draw.MolsToGridImage(rd_mols, molsPerRow=len(mols), subImgSize=(size, size))
+
+    if isinstance(grid_img, bytes):
+        grid_img = PilImage.open(io.BytesIO(grid_img))
+    images = []
+
+    for idx, frame_color in enumerate(frame_colors):
+        image_obj = grid_img.crop((size * idx, 0, size * (idx + 1), size))
+        image_obj = crop_image(image_obj)
+        images.append(draw_rounded_rectangle(image_obj, frame_color))
+
+    return images
+
+
+class RouteImageFactory:
+    def __init__(self, route: Route, margin: int = 100, mol_size: int = 400):
+        in_stock_colors = {True: "green", False: "orange"}
+        self.margin = margin
+        self.mol_size = mol_size
+        font_size = max(16, self.mol_size // 15)
+        self.font = ImageFont.load_default()
+
+        self._smiles_lookup = dict(self._extract_molecules_from_node(route.root_node))
+
+        images = molecules_to_images(
+            self._smiles_lookup.keys,
+            [in_stock_colors[val] for val in self._smiles_lookup.values()],
+            size=self.mol_size,
+        )
+        self._image_lookup = dict(zip(self._smiles_lookup.keys(), images, strict=True))
+
+        self._mol_tree = self._build_plot_tree(route.root_node)
+        self._add_effective_size(self._mol_tree)
+        pos0 = (
+            self._mol_tree["eff_width"] - self._mol_tree["image"].width + self.margin,
+            int(self._mol_tree["eff_height"] * 0.5) - int(self._mol_tree["image"].height * 0.5),
+        )
+        self._add_pos(self._mol_tree, pos0)
+
+        self.image = PilImage.new(
+            "RGB",
+            (self._mol_tree["eff_width"] + self.margin, self._mol_tree["eff_height"]),
+            "white",
+        )
+        self._draw = ImageDraw.Draw(self.image)
+        self._make_image(self._mol_tree)
+        # self.image = crop_image(self.image, margin=0)
+
+    def _extract_molecules_from_node(self, node: Node) -> Generator[tuple[str, bool], None, None]:
+        if isinstance(node, MolNode):
+            yield (node.smiles, node.in_stock)
+
+        for child in node.children:
+            self._extract_molecules_from_node(child)
+
+    def _build_plot_tree(self, node: Node) -> dict | None:
+        if not isinstance(node, MolNode):
+            return None
+
+        tree_dict = {
+            "smiles": node.smiles,
+            "image": self._image_lookup[node.smiles],
+            "id": node.id_in_route,
+        }
+
+        children_trees = []
+        if node.children:
+            reaction_node = node.children[0]
+
+            if isinstance(reaction_node, ReactionNode):
+                for reactant_node in reaction_node.children:
+                    child_tree = self._build_plot_tree(reactant_node)
+                    if child_tree:
+                        children_trees.append(child_tree)
+
+        tree_dict["children"] = children_trees
+        return tree_dict
+
+    def _add_effective_size(self, tree_dict: dict):
+        children = tree_dict.get("children", [])
+        for child in children:
+            self._add_effective_size(child)
+        if children:
+            tree_dict["eff_height"] = sum(c["eff_height"] for c in children) + self.margin * (
+                len(children) - 1
+            )
+            tree_dict["eff_width"] = (
+                max(c["eff_width"] for c in children) + tree_dict["image"].width + self.margin
+            )
+        else:
+            tree_dict["eff_height"] = tree_dict["image"].height
+            tree_dict["eff_width"] = tree_dict["image"].width + self.margin
+
+    def _add_pos(self, tree_dict: dict, pos: tuple[int, int]):
+        tree_dict["left"] = pos[0]
+        tree_dict["top"] = pos[1]
+        children = tree_dict.get("children")
+        if not children:
+            return
+        mid_y = pos[1] + int(tree_dict["image"].height * 0.5)
+        children_height = sum(c["eff_height"] for c in children) + self.margin * (
+            len(children) - 1
+        )
+        childen_leftmost = pos[0] - self.margin - max(c["image"].width for c in children)
+        child_y = mid_y - int(children_height * 0.5)
+        for child in children:
+            y_adjust = int((child["eff_height"] - child["image"].height) * 0.5)
+            self._add_pos(child, (childen_leftmost, child_y + y_adjust))
+            child_y += self.margin + child["eff_height"]
+
+    def _make_image(self, tree_dict: dict):
+        self.image.paste(tree_dict["image"], (tree_dict["left"], tree_dict["top"]))
+        self._draw_number_on_frame(tree_dict)
+        children = tree_dict.get("children")
+        if not children:
+            return
+        children_right = max(c["left"] + c["image"].width for c in children)
+        mid_x = children_right + int(0.5 * (tree_dict["left"] - children_right))
+        mid_y = tree_dict["top"] + int(tree_dict["image"].height * 0.5)
+        self._draw.line((tree_dict["left"], mid_y, mid_x, mid_y), fill="black", width=3)
+        for child in children:
+            self._make_image(child)
+            child_mid_y = child["top"] + int(0.5 * child["image"].height)
+            self._draw.line(
+                (
+                    mid_x,
+                    mid_y,
+                    mid_x,
+                    child_mid_y,
+                    child["left"] + child["image"].width,
+                    child_mid_y,
+                ),
+                fill="black",
+                width=3,
+            )
+        self._draw.ellipse(
+            (mid_x - 8, mid_y - 8, mid_x + 8, mid_y + 8), fill="black", outline="black"
+        )
+
+    def _draw_number_on_frame(self, tree_dict: dict):  # REVISED METHOD
+        """Draws the molecule ID as black text on the top-left corner of its frame."""
+        image_x, image_y = tree_dict["left"], tree_dict["top"]
+        mol_id = tree_dict["id"]
+        text = str(mol_id)
+
+        # Define a simple padding from the corner
+        padding = 8
+        text_pos = (image_x + padding, image_y + padding)
+
+        # Draw the text directly onto the canvas with the new color
+        self._draw.text(
+            text_pos,
+            text,
+            font=self.font,
+            fill="black",  # Changed from "white"
+        )

--- a/src/reagentai/tools/helpers.py
+++ b/src/reagentai/tools/helpers.py
@@ -1,55 +1,94 @@
+from typing import Literal
+
 from src.reagentai.models.retrosynthesis import (
     MolNode,
-    Node,
     ReactionMetadata,
     ReactionNode,
     Route,
-    Score,
+    ScoreData,
 )
 
 
-def parse_node(node_dict: dict) -> Node | None:
+class NodeProcessingState:
+    """Helper class to keep track of ID counters and collected nodes."""
+
+    def __init__(self):
+        self.mol_counter: int = 0
+        self.react_counter: int = 0
+        self.processed_mol_nodes: list[MolNode] = []
+        self.processed_reaction_nodes: list[ReactionNode] = []
+
+    def get_next_id(self, node_type: Literal["mol", "reaction"]) -> str:
+        if node_type == "mol":
+            self.mol_counter += 1
+            return f"mol-{self.mol_counter}"
+        elif node_type == "reaction":
+            self.react_counter += 1
+            return f"react-{self.react_counter}"
+        else:
+            raise ValueError(f"Unknown node type for ID generation: {node_type}")
+
+
+def parse_route_score(score_dict: dict) -> ScoreData:
+    key_map = {
+        "state score": "state_score",
+        "number of reactions": "n_reactions",
+        "number of pre-cursors": "n_precursors",
+        "number of pre-cursors in stock": "n_precursors_in_stock",
+        "average template occurrence": "avg_template_occurence",
+    }
+
+    parsed_score_dict = {}
+    for llm_key, pydantic_key in key_map.items():
+        if llm_key in score_dict:
+            parsed_score_dict[pydantic_key] = score_dict[llm_key]
+
+    return ScoreData(**parsed_score_dict)
+
+
+def parse_node(node_dict: dict, state: NodeProcessingState) -> str:
     node_type = node_dict.get("type")
     children_data = node_dict.get("children", [])
-    parsed_children = [parse_node(child) for child in children_data if isinstance(child, dict)]
-    parsed_children = [child for child in parsed_children if child is not None]
+
+    current_node_id = state.get_next_id(node_type)
+
+    child_ids = []
+    for child_dict in children_data:
+        child_id = parse_node(child_dict, state)
+        child_ids.append(child_id)
+
+    node_data = {
+        "id": current_node_id,
+        "smiles": node_dict["smiles"],
+        "children": child_ids,
+    }
 
     if node_type == "mol":
-        return MolNode(
-            type=node_dict.get("type"),
-            in_stock=node_dict.get("in_stock", False),
-            is_chemical=node_dict.get("is_chemical", False),
-            smiles=node_dict.get("smiles", ""),
-            children=parsed_children,
-        )
+        node_data["in_stock"] = node_dict.get("in stock", False)
+        node_data["is_chemical"] = node_dict.get("is chemical", True)
+        parsed_node = MolNode(**node_data)
+        state.processed_mol_nodes.append(parsed_node)
     elif node_type == "reaction":
-        metadata_dict = node_dict.get("metadata", {})
-        parsed_metadata = ReactionMetadata(
-            classification=metadata_dict.get("classification", "N/A"),
-            policy_probability=metadata_dict.get("policy_probability", 0.0),
+        metadata = ReactionMetadata(
+            classification=node_dict.get("classification", ""),
+            policy_probability=node_dict.get("policy probability", 0.0),
         )
-        return ReactionNode(
-            type=node_dict.get("type"),
-            smiles=node_dict.get("smiles", ""),
-            metadata=parsed_metadata,
-            children=parsed_children,
-        )
-    return None
+        node_data["metadata"] = metadata
+        parsed_node = ReactionNode(**node_data)
+        state.processed_reaction_nodes.append(parsed_node)
+
+    return current_node_id
 
 
 def parse_route_dict(route_dict: dict) -> Route:
-    score_data = route_dict["scores"]
-    parsed_score = Score(
-        state_score=score_data["state score"],
-        n_reactions=score_data["number of reactions"],
-        n_precursors=score_data["number of pre-cursors"],
-        n_precursors_in_stock=score_data["number of pre-cursors in stock"],
-        avg_template_occurence=score_data["average template occurrence"],
+    score_data = parse_route_score(route_dict["scores"])
+    processing_state = NodeProcessingState()
+
+    root_node_id = parse_node(route_dict, processing_state)
+
+    return Route(
+        score_data=score_data,
+        root_node_id=root_node_id,
+        mol_nodes=processing_state.processed_mol_nodes,
+        reaction_nodes=processing_state.processed_reaction_nodes,
     )
-
-    parsed_root_node = parse_node(route_dict)
-
-    if parsed_root_node is None:
-        raise ValueError("Invalid route structure: root node is None or invalid.")
-
-    return Route(score=parsed_score, root_node=parsed_root_node)

--- a/src/reagentai/tools/helpers.py
+++ b/src/reagentai/tools/helpers.py
@@ -58,7 +58,7 @@ def parse_route_score(score_dict: dict) -> ScoreData:
         "number of reactions": "n_reactions",
         "number of pre-cursors": "n_precursors",
         "number of pre-cursors in stock": "n_precursors_in_stock",
-        "average template occurrence": "avg_template_occurence",
+        "average template occurrence": "avg_template_occurrence",
     }
 
     parsed_score_dict = {}
@@ -99,7 +99,7 @@ def parse_node(node_dict: dict, state: NodeProcessingState) -> str:
 
     if node_type == "mol":
         node_data["in_stock"] = node_dict.get("in_stock", False)
-        node_data["is_chemical"] = node_dict.get("is_chemical", True)
+        node_data["is_chemical"] = node_dict.get("is_chemical", False)
         parsed_node = MolNode(**node_data)
         state.processed_mol_nodes.append(parsed_node)
     elif node_type == "reaction":
@@ -173,7 +173,7 @@ def draw_rounded_rectangle(
         img: The PIL Image to draw on.
         color: Color of the rectangle border.
         arc_size: Diameter of the corner arcs.
-        border_width: Width of the border line.
+        width: Width of the border line.
 
     Returns:
         A new PIL Image with the rounded rectangle border.

--- a/src/reagentai/tools/retrosynthesis.py
+++ b/src/reagentai/tools/retrosynthesis.py
@@ -112,7 +112,7 @@ def perform_retrosynthesis(
         raise ValueError(f"No retrosynthesis routes found for target: {target_smile}")
 
     # 4. Convert to RouteCollection
-    routes = [parse_route_dict(route) for route in routes]
+    routes = [parse_route_dict(route, idx) for idx, route in enumerate(routes)]
     route_collection = RouteCollection(routes=routes, n_routes=len(routes))
     logger.info(f"Found {len(route_collection)} retrosynthesis routes for {target_smile}.")
 

--- a/src/reagentai/tools/retrosynthesis.py
+++ b/src/reagentai/tools/retrosynthesis.py
@@ -45,9 +45,7 @@ def initialize_aizynthfinder(
     if RetrosynthesisCache.finder_config is None:
         RetrosynthesisCache.finder_config = config
     elif RetrosynthesisCache.finder_config != config:
-        logger.warning(
-            "Configuration has changed since the last initialization. Clearing cache."
-        )
+        logger.warning("Configuration has changed since the last initialization. Clearing cache.")
         RetrosynthesisCache.clear()
         RetrosynthesisCache.finder_config = config
 

--- a/src/reagentai/tools/smiles.py
+++ b/src/reagentai/tools/smiles.py
@@ -1,13 +1,6 @@
 import logging
-import tempfile
 
-from PIL import Image
 from rdkit import Chem
-from rdkit.Chem import Draw
-
-from src.reagentai.models.retrosynthesis import Route
-
-from .helpers import RouteImageFactory
 
 logger = logging.getLogger(__name__)
 
@@ -31,48 +24,3 @@ def is_valid_smiles(smiles: str, sanitize: bool = True) -> bool:
     logging.info(f"SMILES: {smiles}, Valid: {mol is not None}")
 
     return mol is not None
-
-
-def smiles_to_image(smiles: str, size: tuple[int, int] = (600, 300)) -> str:
-    """
-    Generate an image from a SMILES string.
-
-    Args:
-        smiles (str): The SMILES string to convert to an image.
-        size (tuple[int, int]): The size of the image in pixels. Default is (600, 300).
-
-    Returns:
-        str: The file path to the generated image.
-    """
-    mol = Chem.MolFromSmiles(smiles)
-    if mol is None:
-        raise ValueError(f"Invalid SMILES string: {smiles}")
-
-    PIL_img: Image.Image = Draw.MolToImage(mol, size=size, kekulize=True)
-
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
-        PIL_img.save(tmp_file, format="PNG")
-        temp_file_path = tmp_file.name
-
-    return temp_file_path
-
-
-def route_to_image(routes: Route) -> str:
-    """
-    Generate an image from a SMILES route.
-
-    Args:
-        routes (RouteCollection): The collection of retrosynthesis routes.
-        idx (int): The index of the route to generate an image for. Default is 0.
-
-    Returns:
-        str: The file path to the generated image.
-    """
-    print("Generating image for route...")
-    image = RouteImageFactory(routes).image
-
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
-        image.save(tmp_file, format="PNG")
-        temp_file_path = tmp_file.name
-
-    return temp_file_path

--- a/src/reagentai/tools/smiles.py
+++ b/src/reagentai/tools/smiles.py
@@ -5,6 +5,10 @@ from PIL import Image
 from rdkit import Chem
 from rdkit.Chem import Draw
 
+from src.reagentai.models.retrosynthesis import Route
+
+from .helpers import RouteImageFactory
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,6 +52,27 @@ def image_from_smiles(smiles: str, size: tuple[int, int] = (300, 300)) -> str:
 
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
         PIL_img.save(tmp_file, format="PNG")
+        temp_file_path = tmp_file.name
+
+    return temp_file_path
+
+
+def route_to_image(routes: Route) -> str:
+    """
+    Generate an image from a SMILES route.
+
+    Args:
+        routes (RouteCollection): The collection of retrosynthesis routes.
+        idx (int): The index of the route to generate an image for. Default is 0.
+
+    Returns:
+        str: The file path to the generated image.
+    """
+    print("Generating image for route...")
+    image = RouteImageFactory(routes).image
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
+        image.save(tmp_file, format="PNG")
         temp_file_path = tmp_file.name
 
     return temp_file_path

--- a/src/reagentai/tools/smiles.py
+++ b/src/reagentai/tools/smiles.py
@@ -21,6 +21,6 @@ def is_valid_smiles(smiles: str, sanitize: bool = True) -> bool:
     except Exception:
         mol = None
 
-    logging.info(f"SMILES: {smiles}, Valid: {mol is not None}")
+    logger.info(f"SMILES: {smiles}, Valid: {mol is not None}")
 
     return mol is not None


### PR DESCRIPTION
This pull request introduces significant enhancements to the retrosynthesis functionality, including new tools for visualizing routes and molecules, a refactor of the retrosynthesis data model, and helper utilities for processing retrosynthesis routes. Key changes include the addition of image generation for retrosynthesis routes, updates to the retrosynthesis data model for better structure and clarity, and improvements to helper functions for parsing and processing retrosynthesis data.

### Enhancements to retrosynthesis visualization:
* Added `route_to_image` and `smiles_to_image` functions in `src/reagentai/tools/drawing.py` to generate images for retrosynthesis routes and SMILES strings. These images are saved to temporary files for use in workflows.
* Introduced the `RouteImageFactory` class in `src/reagentai/tools/helpers.py` to create detailed tree-structured images of retrosynthesis routes, including molecule and reaction nodes.

### Updates to retrosynthesis data model:
* Refactored the data model in `src/reagentai/models/retrosynthesis.py`:
  - Renamed `Score` to `ScoreData` for clarity.
  - Added a `NodeBase` class to serve as a common base for `MolNode` and `ReactionNode`.
  - Updated `Route` to include lists of molecular and reaction nodes, replacing the previous nested structure.
* Fixed a typo in the `ScoreData` model attribute `avg_template_occurrence`.

### Improvements to helper functions:
* Refactored the `parse_node` and `parse_route_dict` functions in `src/reagentai/tools/helpers.py` to use the new `NodeProcessingState` class for managing node IDs and processed nodes. This improves modularity and readability.
* Enhanced the `parse_route_score` function to map keys from the LLM response to the `ScoreData` model, ensuring consistency.

### Integration of new tools:
* Updated `src/reagentai/agents/main/main_agent.py` to include the new `route_to_image` tool in the `create_main_agent` function, enabling image generation for retrosynthesis routes.

### Code cleanup and consolidation:
* Moved the `smiles_to_image` function from `src/reagentai/tools/smiles.py` to `src/reagentai/tools/drawing.py` for better organization. [[1]](diffhunk://#diff-e2231a287596e1272ebea1b2b5f07ce522accb18a556c50ebcd96c3fc5860ee7L2-L6) [[2]](diffhunk://#diff-c61ebb787bb2c75ffd51c4514ac2bd418bd8c516c8cbe621474be9db0bf72f55R8-R13)
* Replaced direct `logging.info` calls with the `logger` object in `src/reagentai/tools/smiles.py` for consistency.